### PR TITLE
correct Makefile for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-bin    = $(shell npm bin)
+bin    = "$(shell npm bin)"
 stylus = $(bin)/stylus
 sjs    = $(bin)/sjs
 nw     = nw


### PR DESCRIPTION
`npm bin` on windows returns path with `\` and it breaks Makefile
